### PR TITLE
Null checking in CAD.cs

### DIFF
--- a/CAD.cs
+++ b/CAD.cs
@@ -35,23 +35,29 @@ namespace Dievas {
 		}
 
 		public UnitDto UpdateUnitField(string radioName, string field, string value) {
-			UnitDto unit = new UnitDto{};
-			if (_units.ContainsKey(radioName)) unit = _units[radioName];
-			
-			unit[field] = value;
-			_units[radioName] = unit;		    
-		    
-		    return _units[radioName];
+            UnitDto unit;
+
+			if (_units.TryGetValue(radioName, out unit))
+			{
+				unit[field] = value;
+				_units[radioName] = unit;
+
+				return _units[radioName];
+			}
+			return null;
 		}
 
 		public UnitDto UpdateUnitStatus(string radioName, int statusId) {
-			UnitDto unit = new UnitDto {};
-			if (_units.ContainsKey(radioName)) unit = _units[radioName];
-			
-			unit.StatusId = statusId;
-			_units[radioName] = unit;		    
+			UnitDto unit;
+
+			if (_units.TryGetValue(radioName,out unit))
+			{
+				unit.StatusId = statusId;
+				_units[radioName] = unit;		    
 		    
-		    return _units[radioName];
+				return _units[radioName];
+			}
+			return null;	
 		}
 
 		public IEnumerable GetIncidents() {

--- a/CAD.cs
+++ b/CAD.cs
@@ -86,12 +86,15 @@ namespace Dievas {
 		// return the value to the dict
 		public IncidentDto UpdateIncidentField(int id, string field, string value){
 
-			IncidentDto incident = new IncidentDto {};
+            IncidentDto incident;
 
-			if (_incidents.ContainsKey(id)) incident = _incidents[id];
-			incident[field] = value;
-			_incidents[id] = incident;		    
-		    return _incidents[id];
+			if (_incidents.TryGetValue(id, out incident))
+			{
+				incident[field] = value;
+				_incidents[id] = incident;
+				return _incidents[id];
+			}
+			return null;
 		}
 
 		public IncidentDto AddOrUpdateIncidentUnit(int id, UnitAssignmentDto unit) {

--- a/CAD.cs
+++ b/CAD.cs
@@ -101,20 +101,26 @@ namespace Dievas {
 			globalUnit.StatusId = unit.StatusId;
 			AddOrUpdateUnit(globalUnit);
 
-			// Update unit on incident
-			IncidentDto incident = new IncidentDto {};
+            // Update unit on incident
+            IncidentDto incident;
 
-			if (_incidents.ContainsKey(id)) incident = _incidents[id];
+			if (_incidents.TryGetValue(id, out incident))
+			{
+                incident.UnitsAssigned ??= new List<UnitAssignmentDto>();
+                var unitKey = incident.UnitsAssigned.IndexOf(unit);
 
-            var unitKey = incident.UnitsAssigned.IndexOf(unit);
-            
-            if (unitKey < 0) {
-                incident.UnitsAssigned.Add(unit);
-            } else {
-                incident.UnitsAssigned[unitKey] = unit;
-            }
-            _incidents[id] = incident;
-            return incident;
+				if (unitKey < 0)
+				{
+					incident.UnitsAssigned.Add(unit);
+				}
+				else
+				{
+					incident.UnitsAssigned[unitKey] = unit;
+				}
+				_incidents[id] = incident;
+				return incident;
+			}
+			return null;
 		}
 
 		public IncidentDto AddOrUpdateIncidentUnit(int id, UnitDto unit) {

--- a/CAD.cs
+++ b/CAD.cs
@@ -108,6 +108,7 @@ namespace Dievas {
 			// Update global unit
 			UnitDto globalUnit = GetUnitByName(unit.RadioName);
 			globalUnit.StatusId = unit.StatusId;
+			globalUnit.IncidentId = unit.IncidentId;
 			AddOrUpdateUnit(globalUnit);
 
             // Update unit on incident

--- a/CAD.cs
+++ b/CAD.cs
@@ -107,6 +107,7 @@ namespace Dievas {
 
 			// Update global unit
 			UnitDto globalUnit = GetUnitByName(unit.RadioName);
+			globalUnit.RadioName = unit.RadioName;
 			globalUnit.StatusId = unit.StatusId;
 			globalUnit.IncidentId = unit.IncidentId;
 			AddOrUpdateUnit(globalUnit);

--- a/CAD.cs
+++ b/CAD.cs
@@ -156,11 +156,8 @@ namespace Dievas {
 
 			if (_incidents.TryGetValue(id, out incident))
 			{
-				if (incident.Comments == null)
-				{
-					incident.Comments = new List<CommentDto>();
-				}
-
+				incident.Comments ??= new List<CommentDto>();
+				
 				var commentKey = incident.Comments.IndexOf(comment);
 
 				if (commentKey < 0) {

--- a/CAD.cs
+++ b/CAD.cs
@@ -145,19 +145,26 @@ namespace Dievas {
 		}
 
 		public IncidentDto AddOrUpdateIncidentComment(int id, CommentDto comment){
-			IncidentDto incident = new IncidentDto {};
+			IncidentDto incident;
 
-			if (_incidents.ContainsKey(id)) incident = _incidents[id];
+			if (_incidents.TryGetValue(id, out incident))
+			{
+				if (incident.Comments == null)
+				{
+					incident.Comments = new List<CommentDto>();
+				}
 
-			var commentKey = incident.Comments.IndexOf(comment);
+				var commentKey = incident.Comments.IndexOf(comment);
 
-            if (commentKey < 0) {
-                incident.Comments.Add(comment);
-            } else {
-                incident.Comments[commentKey] = comment;
-            }
-            _incidents[id] = incident;
-            return incident;
+				if (commentKey < 0) {
+					incident.Comments.Add(comment);
+				} else {
+					incident.Comments[commentKey] = comment;
+				}
+				_incidents[id] = incident;
+				return incident;
+			}
+			return null;
 		}
 
 		public int IncidentCount() {

--- a/CAD.cs
+++ b/CAD.cs
@@ -122,26 +122,33 @@ namespace Dievas {
 			// Update global unit
 			AddOrUpdateUnit(unit);
 
-			UnitAssignmentDto assignedUnit = new UnitAssignmentDto { };
-
-			assignedUnit.RadioName = unit.RadioName;
-			assignedUnit.StatusId = unit.StatusId;
-
+			UnitAssignmentDto assignedUnit = new UnitAssignmentDto { 
+				RadioName = unit.RadioName,
+				StatusId = unit.StatusId,
+				IncidentId = id
+			};
 
 			// Update unit on incident
-			IncidentDto incident = new IncidentDto {};
+			IncidentDto incident;
 
-			if (_incidents.ContainsKey(id)) incident = _incidents[id];
+			if (_incidents.TryGetValue(id, out incident))
+			{
+				incident.UnitsAssigned ??= new List<UnitAssignmentDto>();
 
-            var unitKey = incident.UnitsAssigned.IndexOf(assignedUnit);
-            
-            if (unitKey < 0) {
-                incident.UnitsAssigned.Add(assignedUnit);
-            } else {
-                incident.UnitsAssigned[unitKey] = assignedUnit;
-            }
-            _incidents[id] = incident;
-            return incident;
+				var unitKey = incident.UnitsAssigned.IndexOf(assignedUnit);
+
+				if (unitKey < 0)
+				{
+					incident.UnitsAssigned.Add(assignedUnit);
+				}
+				else
+				{
+					incident.UnitsAssigned[unitKey] = assignedUnit;
+				}
+				_incidents[id] = incident;
+				return incident;
+			}
+			return null;
 		}
 
 		public IncidentDto AddOrUpdateIncidentComment(int id, CommentDto comment){

--- a/Hubs/DashboardHub.cs
+++ b/Hubs/DashboardHub.cs
@@ -17,6 +17,7 @@ namespace Dievas.Hubs {
         Task UnitHomeChanged(string radioName, string homeStation);
         Task GetAllIncidents(int minutesPast);
         Task GetAllUnits();
+        Task GetIncident(int incidentId);
     }
 
     //  Here we handle general client communications
@@ -99,19 +100,25 @@ namespace Dievas.Hubs {
         // Update incident field
         public async Task IncidentFieldChanged(int incidentId, string field, string value){
             await Clients.Group("dashboard").IncidentFieldChanged(incidentId, field, value);
-            _cad.UpdateIncidentField(incidentId, field, value);
+            var result = _cad.UpdateIncidentField(incidentId, field, value);
+            if (result == null) 
+                await GetIncident(incidentId);
         }
 
         // Change unit status
         public async Task IncidentUnitStatusChanged(int incidentId, UnitAssignmentDto unit){
             await Clients.Group("dashboard").IncidentUnitStatusChanged(incidentId, unit);
-            _cad.AddOrUpdateIncidentUnit(incidentId, unit);
+            var result = _cad.AddOrUpdateIncidentUnit(incidentId, unit);
+            if (result == null)
+                await GetIncident(incidentId);
         }
 
         // Add comment to incidnet
         public async Task IncidentCommentAdded(int incidentId, CommentDto comment) {
             await Clients.Group("dashboard").IncidentCommentAdded(incidentId, comment);
-            _cad.AddOrUpdateIncidentComment(incidentId, comment);
+            var result = _cad.AddOrUpdateIncidentComment(incidentId, comment);
+            if (result == null)
+                await GetIncident(incidentId);
         }
 
         // Update unit status for non-incidents
@@ -170,6 +177,11 @@ namespace Dievas.Hubs {
         public async Task GetAllIncidents(int minutesPast)
         {
             await Clients.Group("dataFeed").GetAllIncidents(minutesPast);
+        }
+
+        public async Task GetIncident(int incidentId)
+        {
+            await Clients.Group("dataFeed").GetIncident(incidentId);
         }
     }
 }


### PR DESCRIPTION
Added lines to perform more comprehensive null-checking and correction.  There were several nulls populating or throwing errors in the CAD.cs object. 

Also added a "GetIncident" method to DashboardHub.cs to allow CAD.cs to correct when this condition occurs.  If an assignment, comment, field change comes in for an incident that isn't in the dictionary, Dievas will explicitly request a re-sync on that incident.  This shouldn't need to happen in normal operation, but perhaps it can smooth over any blips in connectivity.