### PR TITLE
Update other unit fields

### DIFF
--- a/Hubs/DashboardHub.cs
+++ b/Hubs/DashboardHub.cs
@@ -14,7 +14,6 @@ namespace Dievas.Hubs {
         Task IncidentUnitStatusChanged(int incidentId, UnitAssignmentDto unit);
         Task IncidentCommentAdded(int incidentId, CommentDto comment);
         Task UnitStatusChanged(string radioName, int statusId);
-        Task UnitHomeChanged(string radioName, string homeStation);
         Task UnitFieldChanged(string radioName, string field, Object value);
         Task GetAllIncidents(int minutesPast);
         Task GetAllUnits();
@@ -119,12 +118,6 @@ namespace Dievas.Hubs {
         public async Task UnitStatusChanged(string radioName, int statusId) {
             await Clients.Group("dashboard").UnitStatusChanged(radioName, statusId);
             _cad.UpdateUnitStatus(radioName, statusId);
-        }
-        
-        // Change home station for unit
-        public async Task UnitHomeChanged(string radioName, string homeStation){
-            await Clients.Group("dashboard").UnitHomeChanged(radioName, homeStation);
-            _cad.UpdateUnitField(radioName, "HomeStation", homeStation);
         }
 
         public async Task UnitFieldChanged(string radioName, string field, string value)

--- a/Hubs/DashboardHub.cs
+++ b/Hubs/DashboardHub.cs
@@ -15,6 +15,7 @@ namespace Dievas.Hubs {
         Task IncidentCommentAdded(int incidentId, CommentDto comment);
         Task UnitStatusChanged(string radioName, int statusId);
         Task UnitHomeChanged(string radioName, string homeStation);
+        Task UnitFieldChanged(string radioName, string field, Object value);
         Task GetAllIncidents(int minutesPast);
         Task GetAllUnits();
     }
@@ -124,6 +125,12 @@ namespace Dievas.Hubs {
         public async Task UnitHomeChanged(string radioName, string homeStation){
             await Clients.Group("dashboard").UnitHomeChanged(radioName, homeStation);
             _cad.UpdateUnitField(radioName, "HomeStation", homeStation);
+        }
+
+        public async Task UnitFieldChanged(string radioName, string field, string value)
+        {
+            await Clients.Group("dashboard").UnitFieldChanged(radioName, field, value);
+            _cad.UpdateUnitField(radioName, field, value);
         }
 
         // ***************************************************************************************\


### PR DESCRIPTION
Added method for updating other unit fields. Removed the specific UnitHomeChanged, but unsure if you still need it, though, for downstream emitted events.