### PR TITLE
27 add filtering for units to dashboardcontroller

### DIFF
--- a/CAD.cs
+++ b/CAD.cs
@@ -15,12 +15,8 @@ namespace Dievas {
 
 		private readonly ConcurrentDictionary<string, UnitDto> _units = new ConcurrentDictionary<string, UnitDto>();
 
-		public IEnumerable GetUnits() {
+		public IEnumerable<UnitDto> GetUnits() {
 			return _units.Values.OrderBy( t => t.RadioName );
-		}
-
-		public IEnumerable GetUnitsByStation(string station) {
-			return _units.Values.Where(t => t.HomeStation == station).OrderBy( t => t.RadioName );
 		}
 
 		public UnitDto GetUnitByName(string radioName) {

--- a/Controllers/DashboardController.cs
+++ b/Controllers/DashboardController.cs
@@ -55,9 +55,12 @@ namespace Dievas.Controllers {
         }
 
         [HttpGet("units")]
-        public IEnumerable GetUnits()
-        {
-            return _cad.GetUnits();
+        public IEnumerable GetUnits([FromQuery] string currentJurisdiction, [FromQuery] string currentStation,[FromQuery] string homeJurisdiction, [FromQuery] string homeStation){
+            return _cad.GetUnits().Where(unit =>
+                            (currentJurisdiction is null || unit.CurrentJurisdiction == currentJurisdiction)
+                            && (homeJurisdiction is null || unit.HomeJurisdiction == homeJurisdiction)
+                            && (currentStation is null || unit.CurrentStation == currentStation)
+                            && (homeStation is null || unit.HomeStation == homeStation));
         }
 
         // Web API for data feeds to add incident information


### PR DESCRIPTION
allows for providing a querystring to the /units route to filter by currentstation, homestation, currentjuridiction, and/or homejurisdiction