### PR TITLE
Add StatusUpdateTime support for unit and assignment models

### DIFF
--- a/CAD.cs
+++ b/CAD.cs
@@ -44,6 +44,7 @@ namespace Dievas {
 			if (_units.ContainsKey(radioName)) unit = _units[radioName];
 			
 			unit.StatusId = statusId;
+			unit.StatusUpdateTime = DateTime.UtcNow;
 			_units[radioName] = unit;		    
 		    
 		    return _units[radioName];
@@ -111,6 +112,7 @@ namespace Dievas {
 			UnitDto globalUnit = GetUnitByName(unit.RadioName);
 			globalUnit.StatusId = unit.StatusId;
 			globalUnit.StatusCode = unit.StatusCode;
+			globalUnit.StatusUpdateTime = unit.StatusUpdateTime;
             globalUnit.IncidentId = unit.IncidentId;
             AddOrUpdateUnit(globalUnit);
 
@@ -142,6 +144,7 @@ namespace Dievas {
                 RadioName = unit.RadioName,
                 StatusId = unit.StatusId,
 				StatusCode = unit.StatusCode,
+				StatusUpdateTime = unit.StatusUpdateTime,
                 IncidentId = id
             };
 


### PR DESCRIPTION
## Summary
- Bump `Dashboard.Models` submodule to include `StatusUpdateTime` on `UnitDto` and `UnitAssignmentDto`
- Propagate `StatusUpdateTime` between global units and incident assignments in CAD
- Stamp `DateTime.UtcNow` in `UpdateUnitStatus` so the status-id-only SignalR path still populates the field

Closes #47

## Test plan
- [ ] Confirm submodule initializes to commit with `StatusUpdateTime` on both DTOs
- [ ] Build project successfully after submodule update
- [ ] Send `IncidentUnitStatusChanged` with a `UnitAssignmentDto` that includes `StatusUpdateTime` and verify it is stored on both the assignment and the matching global unit
- [ ] Call `UnitStatusChanged(radioName, statusId)` and verify the unit’s `StatusUpdateTime` is set
- [ ] Merge into updated `main` (post-#46) and confirm no conflicts


Made with [Cursor](https://cursor.com)